### PR TITLE
Potential fix for code scanning alert no. 11: Flask app is run in debug mode

### DIFF
--- a/web_portal.py
+++ b/web_portal.py
@@ -347,4 +347,8 @@ if __name__ == '__main__':
     print("💡 Dependencies will be automatically installed if missing")
     print("=" * 50)
     
-    app.run(host=HOST, port=PORT, debug=True)
+    # Determine environment (default to production)
+    environment = os.environ.get('FLASK_ENV', 'production').lower()
+    is_debug_mode = environment == 'development'
+    
+    app.run(host=HOST, port=PORT, debug=is_debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/KoJesko/ollama-TTS-STT-App/security/code-scanning/11](https://github.com/KoJesko/ollama-TTS-STT-App/security/code-scanning/11)

To fix the issue, the application should disable debug mode when running in a production environment. This can be achieved by introducing an environment variable (e.g., `FLASK_ENV`) or a configuration file to distinguish between development and production environments. The `debug` parameter in `app.run()` should be set dynamically based on the environment. Additionally, the default behavior should prioritize security by disabling debug mode unless explicitly enabled for development.

Steps to implement the fix:
1. Add logic to determine the environment (e.g., using `os.environ` or a configuration file).
2. Set the `debug` parameter in `app.run()` based on the environment.
3. Ensure the application defaults to production mode if the environment is not explicitly set.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
